### PR TITLE
Search for erlang first in ERL_HOME and ERLANG_HOME env variables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ import re
 
 otp_dir = None
 
+def getSearchDir():
+    return os.environ.get('ERL_HOME', os.environ.get('ERLANG_HOME', '/usr'))
+
 def findInSubdirectory(filename, subdirectory=''):
     if subdirectory:
         path = subdirectory
@@ -18,7 +21,7 @@ def findInSubdirectory(filename, subdirectory=''):
             return this_path
     return None
 
-otp_dir = findInSubdirectory('erl_interface.h', '/usr/')
+otp_dir = findInSubdirectory('erl_interface.h', getSearchDir())
 
 if otp_dir == None:
     print 'Cannot find Erlang/OTP directory.'


### PR DESCRIPTION
Search for erlang first in ERL_HOME and ERLANG_HOME env variables not set search in /usr.

Some people are installing erlang somewhere else that in /usr, in particular I am installing it under /opt.

It might be useful to check first if ERL_HOME or ERLANG_HOME are set. It gives you more flexibility, as you can also set an specific version of erlang, if you have multiple versions, and it is also faster as it is not scanning big sub directory tree.
